### PR TITLE
fix tfa in example script

### DIFF
--- a/example.py
+++ b/example.py
@@ -14,6 +14,9 @@ def main():
     inwx_conn = domrobot(api_url, False)
     loginRet = inwx_conn.account.login({'lang': 'en', 'user': username, 'pass': password})
 
+    if 'resData' in loginRet:
+        loginRet = loginRet['resData']
+
     if 'tfa' in loginRet and loginRet['tfa'] == 'GOOGLE-AUTH':
         loginRet = inwx_conn.account.unlock({'tan': getOTP(shared_secret)})
 


### PR DESCRIPTION
Same thing here as with 816398529e21e070a38410b1ac67126bbe21db8e but this time in the example script.